### PR TITLE
Update droid-config-santoni for SailfishOS 3.x

### DIFF
--- a/patterns/jolla-hw-adaptation-santoni.yaml
+++ b/patterns/jolla-hw-adaptation-santoni.yaml
@@ -50,8 +50,6 @@ Requires:
 - nemo-gstreamer1.0-interfaces
 # For devices with droidmedia and gst-droid built, see HADK pdf for more information
 - gstreamer1.0-droid
-- gstreamer1.0-omx
-- gstreamer1.0-libav
 
 # This is needed for notification LEDs
 - mce-plugin-libhybris

--- a/sparse/etc/gst-droid/gstdroidcodec.conf
+++ b/sparse/etc/gst-droid/gstdroidcodec.conf
@@ -1,0 +1,2 @@
+[decoder-quirks]
+video/avc = dont-use-droid-convert;use-codec-supplied-height;use-codec-supplied-width

--- a/sparse/usr/share/csd/settings.d/hw-settings.ini
+++ b/sparse/usr/share/csd/settings.d/hw-settings.ini
@@ -1,0 +1,89 @@
+[features]
+AudioMic1=1
+AudioMic2=1
+BackCamera=1
+BackCameraFlash=1
+Backlight=1
+Battery=1
+Bluetooth=1
+CellularData=1
+CellularVoice=1
+ECompass=1
+FmRadio=1
+FrontCamera=1
+FrontCameraFlash=0
+GPS=1
+CellInfo=1
+GSensor=1
+Gyro=1
+Hall=0
+Fingerprint=1
+Headset=1
+Key=1
+LCD=1
+LED=1
+LightSensor=1
+Loudspeaker=1
+TOH=0
+ProxSensor=1
+Receiver=1
+SDCard=1
+SIM=1
+StereoLoudspeaker=1
+Touch=1
+TouchAuto=0
+UsbCharging=1
+UsbOtg=1
+Vibrator=1
+Wifi=1
+VideoPlayback=1
+
+[BackCamera]
+Flash=1
+# Focus modes:
+# 1 == Manual
+# 2 == Hyperfocal
+# 4 == Infinity
+# 8 == Auto
+# 16 == Continious
+# 32 == Manual
+#FocusMode=8
+
+#[FrontCamera]
+#FocusMode=2
+
+# Each RunInTest can be configured to have a pass rate requirement.
+# By default we're expecting 100% pass rate.
+[FrontBackCamera]
+RunInTestPassRateRequirement=0.95
+
+[LED]
+# Supported types are: Binary, White, AmberGreen, RedGreen, and RGB
+LedType=White
+
+[SIM]
+ModemCount=2
+
+[FmRadio]
+DefaultFrequency=97.7
+InputDevice=input-fm_tuner
+
+# Defaults should be fine for most of the devices,
+# but in case one wants to loosen or stricten the defaults
+# it can be done here.
+#[GSensor]
+#MinY=-1.0
+#MaxY=1.0
+#MinX=-1.0
+#MaxX=1.0
+#MinZ=8.8
+#MaxZ=10.8
+
+# As for GSensor, default should be fine, but if need adjustment
+# Min and Max values set min and max for all axis X, Y and Z
+#[Gyro]
+#Min=-1.3
+#Max=1.3
+
+[Battery]
+VoltageTest=False


### PR DESCRIPTION
Those changes allow 3.0.0.8 image to be build.

* gst-omx is not getting updates anymore and considered obsolete, as gst-droid gained support for OMX_COLOR_FormatYUV420SemiPlanar conversion without relying on libI420colorconvert
* hw-settings.ini was introduced around 2.1.4 and needed for sensors to work in newer versions.

On unrelated note, is the port still active? It would be nice to have it building on OBS (https://wiki.merproject.org/wiki/Adaptations/faq-hadk#Building_things_on_OBS:), as it allows OTA updates and makes port maintenance way easier, and it's possible to build rootfs automatically on CI (see https://gitlab.com/sailfishos-porters-ci).